### PR TITLE
Fix swap example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/.out
+*iml

--- a/src/Cap5/SwapExample.java
+++ b/src/Cap5/SwapExample.java
@@ -1,5 +1,6 @@
 package Cap5;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SwapExample {
@@ -18,7 +19,12 @@ public class SwapExample {
 
     // Exemplo de uso
     public static void main(String[] args) {
-        List<String> strings = List.of("a", "b", "c", "d");
+        List<String> strings = new ArrayList<>();
+        strings.add("a");
+        strings.add("b");
+        strings.add("c");
+        strings.add("d");
+
         System.out.println("Antes da troca: " + strings);
 
         swap(strings, 1, 3);


### PR DESCRIPTION
A inserção de elementos em uma lista através de List.of gera uma lista imutável. Dessa forma, o método swapHelper que faz a troca de dois elementos dentro da lista utilizando o método "set." não funcionava.
![image](https://github.com/devs-javagirl/estudos-java-efetivo/assets/8313184/3498e258-d81a-46fc-80be-d35db2960400)

A correção foi feita criando a lista da forma abaixo:

```
        List<String> strings = new ArrayList<>();
        strings.add("a");
        strings.add("b");
        strings.add("c");
        strings.add("d");
```


Também foi proposta uma melhoria simples no repositório adicionando um .gitignore para os arquivos que o Intellij gera durante o build do projeto (arquivo .iml, pasta /.idea e pasta /.out)